### PR TITLE
Expose weighted Sokoban solver via HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,33 @@ Solve > Play action sequence
 
 *AI calculation duration depends on the size of map and number of boxes. If there is no valid solution,error message will be shown on terminal.*
 
+### API
+
+The solver can also be accessed through an HTTP interface suitable for
+front-ends written in languages such as C#.
+
+Start the service with:
+
+```sh
+uvicorn api:app --reload
+```
+
+Send a `POST` request to `/solve_weighted_sokoban` with a JSON object
+describing the warehouse. Example:
+
+```json
+{
+  "worker": [1, 1],
+  "boxes": [[2, 1]],
+  "targets": [[3, 1]],
+  "walls": [[0,0], [1,0], [2,0], [3,0], [4,0], [0,1], [4,1], [0,2], [1,2], [2,2], [3,2], [4,2]],
+  "weights": [1]
+}
+```
+
+The response contains the action sequence and its total cost or the
+string `"Impossible"` if no solution exists.
+
 ### Screenshots
 
 ![initial-state](images/ss/gameplay1.gif)

--- a/api.py
+++ b/api.py
@@ -1,0 +1,50 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List, Tuple, Optional
+
+import mySokobanSolver as solver
+from sokoban import Warehouse
+
+app = FastAPI()
+
+
+class WarehouseRequest(BaseModel):
+    """Model describing a warehouse configuration.
+
+    The coordinates follow the (x, y) convention where x is the column
+    index and y is the row index.  All lists are expressed as JSON arrays
+    of two integers.  Weights are optional and default to zero if not
+    supplied.
+    """
+
+    worker: Tuple[int, int]
+    boxes: List[Tuple[int, int]]
+    targets: List[Tuple[int, int]]
+    walls: List[Tuple[int, int]]
+    weights: Optional[List[int]] = None
+
+
+def _build_warehouse(data: WarehouseRequest) -> Warehouse:
+    """Create a :class:`Warehouse` instance from the request model."""
+    wh = Warehouse()
+    wh.worker = tuple(data.worker)
+    wh.boxes = [tuple(b) for b in data.boxes]
+    wh.targets = [tuple(t) for t in data.targets]
+    wh.walls = [tuple(w) for w in data.walls]
+    wh.weights = data.weights or [0] * len(wh.boxes)
+    wh.ncols = max((x for x, _ in wh.walls), default=0) + 1
+    wh.nrows = max((y for _, y in wh.walls), default=0) + 1
+    return wh
+
+
+@app.post("/solve_weighted_sokoban")
+def solve_weighted_sokoban_endpoint(data: WarehouseRequest):
+    """Solve a Sokoban puzzle using the weighted solver.
+
+    The endpoint expects a JSON object compatible with :class:`WarehouseRequest`.
+    The response contains either the solution sequence and its total cost or
+    the string ``"Impossible"`` when no solution exists.
+    """
+    warehouse = _build_warehouse(data)
+    solution, cost = solver.solve_weighted_sokoban(warehouse)
+    return {"solution": solution, "cost": cost}


### PR DESCRIPTION
## Summary
- add FastAPI controller exposing `solve_weighted_sokoban`
- document new JSON-based solver endpoint

## Testing
- `python -m py_compile api.py`
- `pip install fastapi pydantic uvicorn --quiet` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_b_68b10a1fd3b883219b30baea09ebbdb0